### PR TITLE
Make sure Hugging Face download stats work, better discoverability #168

### DIFF
--- a/vision_lstm/vision_lstm.py
+++ b/vision_lstm/vision_lstm.py
@@ -11,6 +11,8 @@ from torch import nn
 
 from .vision_lstm_util import interpolate_sincos, to_ntuple, VitPatchEmbed, VitPosEmbed2d, DropPath
 
+from huggingface_hub import PyTorchModelHubMixin
+
 
 class SequenceTraversal(Enum):
     ROWWISE_FROM_TOP_LEFT = "rowwise_from_top_left"
@@ -503,7 +505,7 @@ class ViLBlock(nn.Module):
         self.norm.reset_parameters()
 
 
-class VisionLSTM(nn.Module):
+class VisionLSTM(nn.Module, PyTorchModelHubMixin):
     def __init__(
             self,
             dim=192,


### PR DESCRIPTION
Dear authors,

Thanks for this nice work! I wrote a quick PoC to showcase that you can easily have integration with the 🤗 hub so that you can automatically load the various VisionLSTM models using `from_pretrained` (and push them using `push_to_hub`), track download numbers for your models (similar to models in the Transformers library), and have nice model cards on a per-model basis. It leverages the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class which allows to inherits these methods.

Usage is as follows:

```
from vision_lstm import VisionLSTM

model = VisionLSTM.from_pretrained("nx-ai/vil-tiny")

# optionally, one can push a trained model to the hub
model.push_to_hub("nx-ai/vit-tiny-finetuned")
```

This means people don't need to manually download a checkpoint first in their local environment, it just loads automatically from the hub. I've pushed a demo model here for now: https://huggingface.co/nielsr/vil-tiny. We could move all checkpoints to separate repos to an organization on the hub or your personal user account if you're interested.

See also [this Colab notebook](https://colab.research.google.com/drive/1IwFwtJAhqdIZK22W_s1y-040qHOCMK1U?usp=sharing) for basic usage.

Would you be interested in this integration?

Kind regards,

Niels